### PR TITLE
New option to score by using chad scorer

### DIFF
--- a/scripts/aesthetic.py
+++ b/scripts/aesthetic.py
@@ -1,20 +1,90 @@
 import os
 from pathlib import Path
-from glob import glob
+from glob import escape
 import shutil
+import os
+from modules import scripts, script_callbacks
+from modules.shared import opts
+
+import gradio as gr
+from pathlib import Path
+import torch
+import torch.nn as nn
+import clip
 
 import gradio as gr
 from PIL import Image, ImageFile
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-from webui import wrap_gradio_gpu_call
-from modules import shared, scripts, script_callbacks, ui
-from modules import generation_parameters_copypaste as parameters_copypaste
+from modules import scripts, script_callbacks
 import launch
 
 script_dir = Path(scripts.basedir())
 aesthetics = {}  # name: pipeline
+
+state_name = "sac+logos+ava1-l14-linearMSE.pth"
+if not Path(state_name).exists():
+    url = f"https://github.com/christophschuhmann/improved-aesthetic-predictor/blob/main/{state_name}?raw=true"
+    import requests
+    r = requests.get(url)
+    with open(state_name, "wb") as f:
+        f.write(r.content)
+
+
+class AestheticPredictor(nn.Module):
+    def __init__(self, input_size):
+        super().__init__()
+        self.input_size = input_size
+        self.layers = nn.Sequential(
+            nn.Linear(self.input_size, 1024),
+            nn.Dropout(0.2),
+            nn.Linear(1024, 128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 64),
+            nn.Dropout(0.1),
+            nn.Linear(64, 16),
+            nn.Linear(16, 1)
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+
+
+try:
+    force_cpu = opts.ais_force_cpu
+except:
+    force_cpu = False
+
+if force_cpu:
+    print(f"{extension_name}: Forcing prediction model to run on CPU")
+device = "cuda" if not force_cpu and torch.cuda.is_available() else "cpu"
+# load the model you trained previously or the model available in this repo
+pt_state = torch.load(state_name, map_location=torch.device(device=device))
+
+# CLIP embedding dim is 768 for CLIP ViT L 14
+predictor = AestheticPredictor(768)
+predictor.load_state_dict(pt_state)
+predictor.to(device)
+predictor.eval()
+
+clip_model, clip_preprocess = clip.load("ViT-L/14", device=device)
+
+
+def get_image_features(image, device=device, model=clip_model, preprocess=clip_preprocess):
+    image = preprocess(image).unsqueeze(0).to(device)
+    with torch.no_grad():
+        image_features = model.encode_image(image)
+        # l2 normalize
+        image_features /= image_features.norm(dim=-1, keepdim=True)
+    image_features = image_features.cpu().detach().numpy()
+    return image_features
+
+
+def get_score(image):
+    image_features = get_image_features(image)
+    score = predictor(torch.from_numpy(image_features).to(device).float())
+    return (score.item() / 10) # make it match the other percentile scores
 
 
 def library_check():
@@ -41,6 +111,8 @@ def model_check(name):
             aesthetics["waifu"] = pipeline(
                 "image-classification", model="cafeai/cafe_waifu", device=device
             )
+        elif name == "chad":
+            aesthetics["chad"] = get_score
 
 
 def judge_aesthetic(image):
@@ -69,6 +141,13 @@ def judge_waifu(image):
         result[d["label"]] = d["score"]
     return result
 
+def judge_chad(image):
+    model_check("chad")
+    result = {}
+    score = aesthetics["chad"](image)
+    result["Chad"] = score 
+    return result
+
 
 def judge(image):
     if image is None:
@@ -76,7 +155,8 @@ def judge(image):
     aesthetic = judge_aesthetic(image)
     style = judge_style(image)
     waifu = judge_waifu(image)
-    return aesthetic, style, waifu
+    chad = judge_chad(image)
+    return aesthetic, style, waifu, chad
 
 
 def classify_outputs_folders(type):
@@ -86,41 +166,51 @@ def classify_outputs_folders(type):
         return ["anime", "other", "real_life", "3d", "manga_like"]
     elif type == "Waifu":
         return ["waifu", "not_waifu"]
+    elif type == "ChadPrefix score":
+        return ["Chad/Chad_Score_Number-filename.*"]
+    elif type == "ChadFolder":
+        return ["Chad_Score_Number"]
 
 
-def output_dir_previews_update(value, classify_type):
+def output_dir_previews_update(value, classify_type, save_type):
     if value == "":
         return
-    folders = classify_outputs_folders(classify_type)
+    if not classify_type == "Chad":
+        save_type=""
+    folders = classify_outputs_folders(f"{classify_type}{save_type}")
     output_dir_previews = "\n".join([f"- {Path(value)/f}" for f in folders])
 
-    return f"Output dirs will be created like: \n{output_dir_previews}"
+    return [f"Output dirs will be created like: \n{output_dir_previews}", gr.update(visible = classify_type == "Chad")]
 
 
 def progress_str(progress):
     return int(progress * 1000) / 10
 
 
-def copy_or_move_files(img_path: Path, to: Path, copy, together):
-    img_name = img_path.stem  # hoge.jpg
+def copy_or_move_files(img_path: Path, to: Path, copy, together, img_name = None):
+    
+    if img_name == None:
+        img_name = img_path.stem  # hoge.jpg
+
+    os.makedirs(to, exist_ok=True) # only make dirs when neccessary
     if together:
-        for p in img_path.parent.glob(f"{img_name}.*"):
+        for p in img_path.parent.glob(f"{escape(img_path.stem)}.*"):
             if copy:
-                shutil.copy2(p, to / p.name)
+                shutil.copy2(p, to / f"{img_name}{p.suffix}")
             else:
                 if os.path.exists(p):
-                    p.rename(to / p.name)
+                    p.rename(to / f"{img_name}{p.suffix}")
                 else:
                     print(f"Not found: {p}".encode("utf-8"))
     else:
         if copy:
-            shutil.copy2(img_path, to / img_path.name)
+            shutil.copy2(img_path, to / f"{img_name}{img_path.suffix}")
         else:
-            img_path.rename(to / img_path.name)
+            img_path.rename(to / f"{img_name}{img_path.suffix}")
 
 
 def batch_classify(
-    input_dir, output_dir, classify_type, output_style, together, basis, threshold
+    input_dir, output_dir, classify_type, output_style, saving_style, together, basis, threshold
 ):
     print("Batch classifying started")
     try:
@@ -141,17 +231,16 @@ def batch_classify(
             classifyer = judge_style
         elif classify_type == "Waifu":
             classifyer = judge_waifu
+        elif classify_type == "Chad":
+            classifyer = judge_chad
 
-        folders = classify_outputs_folders(classify_type)
-
-        for f in folders:
-            os.makedirs(output_dir / f, exist_ok=True)
 
         for i, f in enumerate(image_paths):
             if f.is_dir():
                 continue
 
             img = Image.open(f)
+            f_name = f.stem
             result = classifyer(img)
 
             max_score = 0
@@ -169,9 +258,15 @@ def batch_classify(
 
             if max_label is None:
                 continue
-
+            
+            #Chad has only a score
+            if max_label == "Chad" and saving_style == "Folder":
+                max_label = repr(round(max_score*100)) 
+            elif max_label == "Chad":
+                f_name = f"{repr(round(max_score*100))}-{f_name}"
+                
             copy_or_move_files(
-                f, output_dir / max_label, output_style == "Copy", together
+                f, output_dir / max_label, output_style == "Copy", together, f_name
             )
 
             print(
@@ -205,6 +300,7 @@ def on_ui_tabs():
 
                         with gr.Column():
                             single_aesthetic_result = gr.Label(label="Aesthetic")
+                            single_chad_result = gr.Label(label="Chad")
                             single_style_result = gr.Label(label="Style")
                             single_waifu_result = gr.Label(label="Waifu")
 
@@ -227,9 +323,16 @@ def on_ui_tabs():
 
                             classify_type_radio = gr.Radio(
                                 label="Classify type",
-                                choices=["Aesthetic", "Style", "Waifu"],
+                                choices=["Aesthetic", "Style", "Waifu", "Chad"],
                                 value="Aesthetic",
                                 interactive=True,
+                            )
+                            save_style_radio = gr.Radio(
+                                label="Chad save style",
+                                choices=["Prefix score", "Folder"],
+                                value="Prefix score",
+                                interactive=True,
+                                visible = classify_type_radio.value == "Chad"
                             )
 
                             output_style_radio = gr.Radio(
@@ -285,23 +388,28 @@ def on_ui_tabs():
         image.change(
             fn=judge,
             inputs=image,
-            outputs=[single_aesthetic_result, single_style_result, single_waifu_result],
+            outputs=[single_aesthetic_result, single_style_result, single_waifu_result, single_chad_result],
         )
         single_start_btn.click(
             fn=judge,
             inputs=image,
-            outputs=[single_aesthetic_result, single_style_result, single_waifu_result],
+            outputs=[single_aesthetic_result, single_style_result, single_waifu_result, single_chad_result],
         )
 
         output_dir_input.change(
             fn=output_dir_previews_update,
-            inputs=[output_dir_input, classify_type_radio],
-            outputs=[output_dir_previews_md],
+            inputs=[output_dir_input, classify_type_radio, save_style_radio],
+            outputs=[output_dir_previews_md, save_style_radio],
         )
         classify_type_radio.change(
             fn=output_dir_previews_update,
-            inputs=[output_dir_input, classify_type_radio],
-            outputs=[output_dir_previews_md],
+            inputs=[output_dir_input, classify_type_radio, save_style_radio],
+            outputs=[output_dir_previews_md, save_style_radio],
+        )
+        save_style_radio.change(
+            fn=output_dir_previews_update,
+            inputs=[output_dir_input, classify_type_radio, save_style_radio],
+            outputs=[output_dir_previews_md, save_style_radio],
         )
 
         batch_start_btn.click(
@@ -311,6 +419,7 @@ def on_ui_tabs():
                 output_dir_input,
                 classify_type_radio,
                 output_style_radio,
+                save_style_radio,
                 copy_or_move_captions_together,
                 basis_radio,
                 absolute_slider,


### PR DESCRIPTION
mostly stolen from: https://github.com/tsngo/stable-diffusion-webui-aesthetic-image-scorer
I was annoyed how buggy the solution was for, all I wanted was some way to sort out scored images, like this extension does.

So I added the option and copied the process from the aesthetic image scorer.

Works with single judge:
![image](https://github.com/p1atdev/stable-diffusion-webui-cafe-aesthetic/assets/1095756/d41c013f-2a04-4ea7-9c4f-d3a180f52077)

When batch processing a new option exists and when selected there are two ways to save:
![image](https://github.com/p1atdev/stable-diffusion-webui-cafe-aesthetic/assets/1095756/82d9eea2-b0d0-438d-b7ce-fe677f70ad0b)

One creates a folder named "Chad" and prefixes the score to the file when copying/moving:

- /path/Chad/45-filename.jpg
- /path/Chad/66-filename.jpg

The other creates for every score that shows up a folder:

- /path/45/filename.jpg
- /path/66/filename.jpg